### PR TITLE
Adjust strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = Parsick;
 
 Parsick.prototype.parse = function (type, source, fields) {
   if(arguments.length < 3) {
-    throw new TypeError('You need send \'type\', \'source\' and \'fields\' to parse your data');
+    throw new TypeError(`You need send 'type', 'source' and 'fields' to parse your data`);
   }
 
   if(!_.has(this.adapters, type)) {

--- a/test/index.js
+++ b/test/index.js
@@ -31,12 +31,12 @@ describe('Parsick module', () => {
 
     it('should have json parser', () => {
       expect(parsick.adapters).to.have.property('json');
-      expect(parsick.adapters.json).to.be.a('function'); 
+      expect(parsick.adapters.json).to.be.a('function');
     });
 
     it('should have xml parser', () => {
       expect(parsick.adapters).to.have.property('xml');
-      expect(parsick.adapters.xml).to.be.a('function'); 
+      expect(parsick.adapters.xml).to.be.a('function');
     });
   });
 
@@ -45,7 +45,7 @@ describe('Parsick module', () => {
       it('when no arguments are passed', () => {
         let fn = () => { parsick.parse() };
         expect(fn).to.be.throw(TypeError);
-        expect(fn).to.be.throw('You need send \'type\', \'source\' and \'fields\' to parse your data');
+        expect(fn).to.be.throw(`You need send 'type', 'source' and 'fields' to parse your data`);
       });
 
       it('when type has a invalid type', () => {


### PR DESCRIPTION
use template block, instead single quote string, for reduce use of escapes:

```js
var str = 'lero lero \'lero\'';
// turn
var str = `lero lero 'lero'`;
```

Is useful to template, like
```js
var str = `hello ${name}`;
```